### PR TITLE
Replace cannotBeEmpty by requiresAtLeastOneElement

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
         $tb->root('rezzza_command_bus')
             ->children()
                 ->arrayNode('buses')
-                    ->cannotBeEmpty()
+                    ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->performNoDeepMerging()
@@ -91,7 +91,7 @@ class Configuration implements ConfigurationInterface
     private function createConsumersNodeDefinition()
     {
         return (new ArrayNodeDefinition('consumers'))
-            ->cannotBeEmpty()
+            ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
             ->prototype('array')
                 ->children()


### PR DESCRIPTION
`Using Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::cannotBeEmpty() at path “rezzza_command_bus.buses” has no effect, consider requiresAtLeastOneElement() instead. In 4.0 both methods will behave the same.`