### PR TITLE
Simplify command handlers declaration

### DIFF
--- a/DependencyInjection/Compiler/CommandHandlerPass.php
+++ b/DependencyInjection/Compiler/CommandHandlerPass.php
@@ -23,11 +23,13 @@ class CommandHandlerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('rezzza_command_bus.command_handler') as $serviceId => $handlers) {
             foreach ($handlers as $data) {
-                if (!isset($data['command'])) {
+                $command = $this->getCommand($serviceId, $handlers, $data);
+
+                if (null === $command) {
                     throw new \LogicException('Please provide a command with "rezzza_command.command_handler" tag');
                 }
 
-                $services[$data['command']] = new Definition('Rezzza\CommandBusBundle\Handler\HandlerServiceDefinition', [
+                $services[$command] = new Definition('Rezzza\CommandBusBundle\Handler\HandlerServiceDefinition', [
                     $serviceId,
                     isset($data['method']) ? $data['method'] : null
                 ]);
@@ -35,5 +37,29 @@ class CommandHandlerPass implements CompilerPassInterface
         }
 
         $container->getDefinition('rezzza_command_bus.command_handler_locator.container')->addArgument($services);
+    }
+
+    private function getCommand(string $serviceId, array $handlers, array $data): ?string
+    {
+        if (isset($data['command'])) {
+            return $data['command'];
+        }
+
+        // if no command is defined the handler should manage only one command
+        if (1 < \count($handlers)) {
+            return null;
+        }
+
+        $command = $this->guessCommandFromHandlerName($serviceId);
+
+        return class_exists($command) ? $command : null;
+    }
+
+    private function guessCommandFromHandlerName(string $handler): string
+    {
+        $parts = preg_split('/(?=[A-Z])/',$handler);
+        array_pop($parts);
+
+        return implode('', $parts);
     }
 }


### PR DESCRIPTION
Simplify command handlers declaration to autowire automatically the services.

From:
```yml
Xeonys\CRM\DataProbe\App\Command\DataProbeMute\DataProbeMuteCommandHandler:
  public: true
  tags:
    - { name: 'rezzza_command_bus.command_handler', command: 'Xeonys\CRM\DataProbe\App\Command\DataProbeMute\DataProbeMuteCommand', method: 'handle' }

Xeonys\CRM\DataProbe\App\Command\DataProbeMarkAsDone\DataProbeMarkAsDoneCommandHandler:
  public: true
  tags:
    - { name: 'rezzza_command_bus.command_handler', command: 'Xeonys\CRM\DataProbe\App\Command\DataProbeMarkAsDone\DataProbeMarkAsDoneCommand', method: 'handle' }
```

To:
```yml
Xeonys\CRM\DataProbe\App\Command\:
  resource: '../../../App/Command/*/*Handler.php'
  tags: [ { name: rezzza_command_bus.command_handler } 
```